### PR TITLE
Replace `frame.data` with `frame.audioChannel()` and `frame.imageData()`

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -37,16 +37,16 @@ module.exports = class FFmpegFrame extends ReferenceCounted {
     binding.setFramePixelFormat(this._handle, value)
   }
 
-  get data() {
-    return Buffer.from(binding.getFrameData(this._handle))
-  }
-
-  channel(i) {
+  audioChannel(i) {
     if (i < 0 || i > 7) {
       throw new RangeError(`Channel index must be between 0 and 7`)
     }
 
-    return Buffer.from(binding.getFrameChannel(this._handle, i))
+    return Buffer.from(binding.getFrameAudioChannel(this._handle, i))
+  }
+
+  imageData() {
+    return Buffer.from(binding.getFrameImageData(this._handle))
   }
 
   lineSize(channel) {

--- a/test/decode.js
+++ b/test/decode.js
@@ -112,7 +112,7 @@ function decodeAudio(audio) {
       decoder.sendPacket(packet)
 
       while (decoder.receiveFrame(frame)) {
-        buffers.push(frame.channel(0))
+        buffers.push(frame.audioChannel(0))
       }
 
       packet.unref()

--- a/test/frame.js
+++ b/test/frame.js
@@ -54,14 +54,14 @@ test('frame expose an alloc method', (t) => {
   })
 })
 
-test('frame expose an data getter', (t) => {
+test('frame expose an imageData method', (t) => {
   const fr = new ffmpeg.Frame()
   fr.height = 200
   fr.width = 200
   fr.pixelFormat = ffmpeg.constants.pixelFormats.RGBA
   fr.alloc()
 
-  t.ok(fr.data instanceof Buffer)
+  t.ok(fr.imageData() instanceof Buffer)
 })
 
 test('frame expose a lineSize method', (t) => {


### PR DESCRIPTION
Frames can hold any type of media so we can't really have `frame.data` only work for image frames. I've renamed the existing `frame.channel()` method to `frame.audioChannel()` and removed `frame.data` in favor of `frame.imageData()` to make the distinction clear.