### PR TITLE
Don't append to `$PATH` on Windows

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -66,11 +66,7 @@ jobs:
         if: ${{ matrix.platform == 'linux' || matrix.platform == 'android' }}
       - run: brew install meson nasm
         if: ${{ matrix.platform == 'darwin' || matrix.platform == 'ios' }}
-      - run: |
-          choco install --ignore-package-exit-codes meson nasm msys2
-          "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
-          "C:\Program Files\Meson" | Out-File -FilePath "$env:GITHUB_PATH" -Append
-          "C:\tools\msys64" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+      - run: choco install --ignore-package-exit-codes meson nasm msys2
         if: ${{ matrix.platform == 'win32' }}
       - run: pacman --noconfirm -S git make ninja pkgconf
         shell: C:\tools\msys64\usr\bin\bash.exe -e {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,11 +71,7 @@ jobs:
         if: ${{ matrix.platform == 'linux' || matrix.platform == 'android' }}
       - run: brew install meson nasm
         if: ${{ matrix.platform == 'darwin' || matrix.platform == 'ios' }}
-      - run: |
-          choco install --ignore-package-exit-codes meson nasm msys2
-          "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
-          "C:\Program Files\Meson" | Out-File -FilePath "$env:GITHUB_PATH" -Append
-          "C:\tools\msys64" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+      - run: choco install --ignore-package-exit-codes meson nasm msys2
         if: ${{ matrix.platform == 'win32' }}
       - run: pacman --noconfirm -S git make ninja pkgconf
         shell: C:\tools\msys64\usr\bin\bash.exe -e {0}


### PR DESCRIPTION
Should be unnecessary after https://github.com/holepunchto/cmake-toolchains/commit/940ddd6ae00f1a29ec3256bb1560b4500870fa4f, https://github.com/holepunchto/cmake-ports/commit/19ef2aa3eaaf5a81c0c47b7ee5fcce31716e8fec, https://github.com/holepunchto/cmake-ports/commit/fbd5ea1e77cbfec04ece491f9fe11fb91c280aeb, and https://github.com/holepunchto/cmake-meson/commit/9f77eb7b3410f6324b8a6fabe898d597da609e6d.