### PR TITLE
add pulseaudio & jackd support

### DIFF
--- a/cmake/ports/ffmpeg/port.cmake
+++ b/cmake/ports/ffmpeg/port.cmake
@@ -88,7 +88,10 @@ elseif(LINUX)
     "--sysroot=${CMAKE_SYSROOT}"
 
     --enable-pthreads
+    --enable-libpulse
+    --enable-libjack
   )
+  target_link_libraries(avdevice INTERFACE pulse jack)
 elseif(ANDROID)
   list(APPEND args
     --target-os=android


### PR DESCRIPTION
Enabled `libpulse` and `libjack` for linux builds