### PR TITLE
fix(input-format): add default url for ios

### DIFF
--- a/lib/format-context.js
+++ b/lib/format-context.js
@@ -71,6 +71,7 @@ let defaultURL = null
 
 switch (Bare.platform) {
   case 'darwin':
+  case 'ios':
     defaultURL = '0:0'
     break
   case 'linux':


### PR DESCRIPTION
Was causing a `bad_optional_access was thrown in -fno-exceptions mode` somewhere in `libjstl` 