### PR TITLE
export UYVY422 constant

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1980,6 +1980,7 @@ bare_ffmpeg_exports(js_env_t *env, js_value_t *exports) {
   V(AV_PIX_FMT_RGB24)
   V(AV_PIX_FMT_YUVJ420P)
   V(AV_PIX_FMT_YUV420P)
+  V(AV_PIX_FMT_UYVY422)
 
   V(AVMEDIA_TYPE_UNKNOWN)
   V(AVMEDIA_TYPE_VIDEO)


### PR DESCRIPTION
noticed `UYVY422` missing
```js
console.log(ffmpeg.constants.pixelFormats)
// => { RGBA: 26, RGB24: 2, YUVJ420P: 12, UYVY422: undefined, YUV420P: 0 }
```