### PR TITLE
fix(scaler): use source height instead of target

### DIFF
--- a/lib/scaler.js
+++ b/lib/scaler.js
@@ -39,10 +39,10 @@ module.exports = class FFmpegScaler {
     if (typeof y !== 'number') {
       target = y
       y = 0
-      height = this._targetHeight
+      height = source.height
     } else if (typeof height !== 'number') {
       target = height
-      height = this._targetHeight
+      height = source.height
     }
 
     return binding.scaleScaler(

--- a/test/scaler.js
+++ b/test/scaler.js
@@ -41,4 +41,3 @@ test('it should preseve line number in case of downscale', (t) => {
     t.ok(lines == targetHeight)
   }
 })
-

--- a/test/scaler.js
+++ b/test/scaler.js
@@ -1,0 +1,44 @@
+const test = require('brittle')
+const ffmpeg = require('..')
+
+test('it should preseve line number in case of downscale', (t) => {
+  const image = require('./fixtures/image/sample.jpeg', {
+    with: { type: 'binary' }
+  })
+
+  const io = new ffmpeg.IOContext(image)
+  using format = new ffmpeg.InputFormatContext(io)
+
+  for (const stream of format.streams) {
+    using packet = new ffmpeg.Packet()
+    format.readFrame(packet)
+
+    using raw = new ffmpeg.Frame()
+    using rgba = new ffmpeg.Frame()
+
+    using decoder = stream.decoder()
+    decoder.sendPacket(packet)
+    decoder.receiveFrame(raw)
+
+    const targetWidth = decoder.width / 2
+    const targetHeight = decoder.height / 2
+
+    rgba.width = targetWidth
+    rgba.height = targetHeight
+    rgba.pixelFormat = ffmpeg.constants.pixelFormats.RGBA
+    rgba.alloc()
+
+    using scaler = new ffmpeg.Scaler(
+      decoder.pixelFormat,
+      decoder.width,
+      decoder.height,
+      rgba.pixelFormat,
+      rgba.width,
+      rgba.height
+    )
+    const lines = scaler.scale(raw, rgba)
+
+    t.ok(lines == targetHeight)
+  }
+})
+


### PR DESCRIPTION
Before:

<img width="1170" height="2532" alt="IMG_7425" src="https://github.com/user-attachments/assets/87a34ddc-6375-48ad-a2a5-26000f0d7d9e" />

After:

<img width="1170" height="2532" alt="IMG_7428" src="https://github.com/user-attachments/assets/587018d4-018b-41a4-8801-ca912c581b96" />