### PR TITLE
add test + rational `q2d`, `d2q` api

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -2448,6 +2448,30 @@ bare_ffmpeg_audio_fifo_space(
   return av_audio_fifo_space(fifo->handle);
 }
 
+static js_arraybuffer_t
+bare_ffmpeg_rational_d2q(
+  js_env_t *env,
+  js_receiver_t,
+  double num
+) {
+  constexpr int safe_max = 1 << 26;
+
+  auto rational = av_d2q(num, safe_max);
+
+  int err;
+
+  js_arraybuffer_t result;
+
+  int32_t *data;
+  err = js_create_arraybuffer(env, 2, data, result);
+  assert(err == 0);
+
+  data[0] = rational.num;
+  data[1] = rational.den;
+
+  return result;
+}
+
 static js_value_t *
 bare_ffmpeg_exports(js_env_t *env, js_value_t *exports) {
   uv_once(&bare_ffmpeg__init_guard, bare_ffmpeg__on_init);
@@ -2621,6 +2645,8 @@ bare_ffmpeg_exports(js_env_t *env, js_value_t *exports) {
   V("resetAudioFifo", bare_ffmpeg_audio_fifo_reset)
   V("getAudioFifoSize", bare_ffmpeg_audio_fifo_size)
   V("getAudioFifoSpace", bare_ffmpeg_audio_fifo_space)
+
+  V("rationalD2Q", bare_ffmpeg_rational_d2q)
 #undef V
 
 #define V(name) \

--- a/lib/rational.js
+++ b/lib/rational.js
@@ -1,3 +1,5 @@
+const binding = require('../binding')
+
 module.exports = class FFmpegRational {
   constructor(numerator = 0, denominator = 1) {
     this.numerator = numerator
@@ -10,7 +12,7 @@ module.exports = class FFmpegRational {
     if (this.denominator < 1) return false
 
     // common initial value for AVRational(0, 1)
-    if (this.q2d() === 0) return false
+    if (this.q2d === 0) return false
 
     return true
   }
@@ -19,7 +21,12 @@ module.exports = class FFmpegRational {
     return this.numerator === 0 && this.denominator === 1
   }
 
-  q2d() {
+  get q2d() {
     return this.numerator / this.denominator
+  }
+
+  static from(num) {
+    const view = new Int32Array(binding.rationalD2Q(num))
+    return new FFmpegRational(view[0], view[1])
   }
 }

--- a/test/rational.js
+++ b/test/rational.js
@@ -1,0 +1,23 @@
+const test = require('brittle')
+const ffmpeg = require('..')
+
+test('validity', (t) => {
+  t.is(new ffmpeg.Rational(1, 60).valid, true)
+  t.is(new ffmpeg.Rational(0, 1).valid, false)
+  t.is(new ffmpeg.Rational(5, -1).valid, false)
+  t.is(new ffmpeg.Rational(-5, 1).valid, true)
+
+  t.is(new ffmpeg.Rational(0, 1).uninitialized, true)
+  t.is(new ffmpeg.Rational(5, -1).uninitialized, false)
+})
+
+test('quantized to double', (t) => {
+  const r = new ffmpeg.Rational(6, 2)
+  t.is(r.q2d, 3)
+})
+
+test('double to quantized', (t) => {
+  const r = ffmpeg.Rational.from(2.5)
+  t.is(r.numerator, 5)
+  t.is(r.denominator, 2)
+})


### PR DESCRIPTION
Exported `number`  => `Rational` (d2q)  as a supplement to previous implentation of `Rational` => `number`  (q2d)

Add Rational test-suite