### PR TITLE
experimental make `extraData` writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,12 @@ Gets the sample rate for audio codecs.
 
 **Returns**: `number`
 
+##### `CodecParameters.extraData`
+
+Out-of-band global headers that may be used by some codecs.
+
+**Returns**: `Buffer`
+
 #### Methods
 
 ##### `CodecParameters.fromContext(context)`

--- a/binding.cc
+++ b/binding.cc
@@ -1387,7 +1387,7 @@ bare_ffmpeg_codec_parameters_set_extra_data(
   size_t min_size = len + AV_INPUT_BUFFER_PADDING_SIZE;
 
   parameters->handle->extradata = reinterpret_cast<uint8_t *>(av_malloc(min_size));
-  memset(parameters->handle->extradata, 0, min_size);
+  memset(&parameters->handle->extradata[len], 0, AV_INPUT_BUFFER_PADDING_SIZE);
 
   memcpy(parameters->handle->extradata, &view[offset], len);
 

--- a/lib/codec-parameters.d.ts
+++ b/lib/codec-parameters.d.ts
@@ -10,6 +10,7 @@ declare class FFmpegCodecParameters {
   readonly nbChannels: number
   readonly codecType: number
   readonly channelLayout: FFmpegChannelLayout
+  extraData: Buffer
 
   constructor(handle: ArrayBuffer)
 

--- a/lib/codec-parameters.js
+++ b/lib/codec-parameters.js
@@ -60,6 +60,21 @@ module.exports = class FFmpegCodecParameters {
     return binding.getCodecParametersHeight(this._handle)
   }
 
+  get extraData() {
+    const arrayBuffer = binding.getCodecParametersExtraData(this._handle)
+    console.log(arrayBuffer)
+    return arrayBuffer ? Buffer.from(arrayBuffer) : undefined
+  }
+
+  set extraData(value) {
+    binding.setCodecParametersExtraData(
+      this._handle,
+      value.buffer,
+      value.byteOffset,
+      value.byteLength
+    )
+  }
+
   fromContext(context) {
     binding.codecParametersFromContext(this._handle, context._handle)
   }
@@ -82,7 +97,8 @@ module.exports = class FFmpegCodecParameters {
       sampleRate: this.sampleRate,
       nbChannels: this.nbChannels,
       channelLayout: this.channelLayout,
-      frameRate: this.frameRate
+      frameRate: this.frameRate,
+      extraData: this.extraData
     }
   }
 }

--- a/lib/codec-parameters.js
+++ b/lib/codec-parameters.js
@@ -61,9 +61,7 @@ module.exports = class FFmpegCodecParameters {
   }
 
   get extraData() {
-    const arrayBuffer = binding.getCodecParametersExtraData(this._handle)
-    console.log(arrayBuffer)
-    return arrayBuffer ? Buffer.from(arrayBuffer) : undefined
+    return Buffer.from(binding.getCodecParametersExtraData(this._handle))
   }
 
   set extraData(value) {

--- a/test/codec-parameters.js
+++ b/test/codec-parameters.js
@@ -1,10 +1,22 @@
 const test = require('brittle')
 const ffmpeg = require('..')
 
-test('CodecParameters class should expose a extraData', (t) => {
+test('CodecParameters class should expose a extraData getter', (t) => {
   const codecParam = getCodecParameters()
 
   t.ok(codecParam.extraData instanceof Buffer) 
+})
+
+test('CodecParameters class should expose a extraData setter', (t) => {
+  const codecParam = getCodecParameters()
+
+  const buf = Buffer.from('test')
+  codecParam.extraData = buf
+
+  t.ok(codecParam.extraData[0] == 't'.charCodeAt(0))
+  t.ok(codecParam.extraData[1] == 'e'.charCodeAt(0))
+  t.ok(codecParam.extraData[2] == 's'.charCodeAt(0))
+  t.ok(codecParam.extraData[3] == 't'.charCodeAt(0))
 })
 
 // Helpers
@@ -14,7 +26,7 @@ function getCodecParameters() {
   options.set('framerate', '30')
   options.set('video_size', '1280x720')
   options.set('pixel_format', 'uyvy422')
-  const inputFormatContext = new ffmpeg.InputFormatContext(
+  using inputFormatContext = new ffmpeg.InputFormatContext(
     new ffmpeg.InputFormat('lavfi'),
     options,
     'testsrc=size=640x480:rate=30'

--- a/test/codec-parameters.js
+++ b/test/codec-parameters.js
@@ -1,0 +1,27 @@
+const test = require('brittle')
+const ffmpeg = require('..')
+
+test('CodecParameters class should expose a extraData', (t) => {
+  const codecParam = getCodecParameters()
+
+  t.ok(codecParam.extraData instanceof Buffer) 
+})
+
+// Helpers
+
+function getCodecParameters() {
+  const options = new ffmpeg.Dictionary()
+  options.set('framerate', '30')
+  options.set('video_size', '1280x720')
+  options.set('pixel_format', 'uyvy422')
+  const inputFormatContext = new ffmpeg.InputFormatContext(
+    new ffmpeg.InputFormat('lavfi'),
+    options,
+    'testsrc=size=640x480:rate=30'
+  )
+  const stream = inputFormatContext.getBestStream(
+    ffmpeg.constants.mediaTypes.VIDEO
+  )
+
+  return stream.codecParameters
+}

--- a/test/codec-parameters.js
+++ b/test/codec-parameters.js
@@ -4,7 +4,7 @@ const ffmpeg = require('..')
 test('CodecParameters class should expose a extraData getter', (t) => {
   const codecParam = getCodecParameters()
 
-  t.ok(codecParam.extraData instanceof Buffer) 
+  t.ok(codecParam.extraData instanceof Buffer)
 })
 
 test('CodecParameters class should expose a extraData setter', (t) => {


### PR DESCRIPTION
added accessor `CodecParameters.extraData` .

#### **Question:** Is CodecParameters props intentionally read-only? 

background: some formats like webm require GLOBAL_HEADER to be set before running `outputFormat.writeHeader()`
or they fail with `EINVAL` 

while encoding, the `extraData` is passed by encoder via `packet.extra_data`,
but when remuxing (no CodecContext active) we have to manually configure the output stream:

```js
const extraData = inputStream.codecParameters.extraData // populated by format loader

outputFormat.streams[0].codecparameters.extraData = extraData

outputFormat.writeHeader()
```

unblocks https://github.com/holepunchto/vcr-core/pull/7