### PR TITLE
Independent CodecParameters

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1208,6 +1208,32 @@ bare_ffmpeg_codec_parameters_to_context(
   }
 }
 
+static js_arraybuffer_t
+bare_ffmpeg_create_codec_parameters(
+  js_env_t *env,
+  js_receiver_t
+) {
+  int err;
+
+  js_arraybuffer_t handle;
+  bare_ffmpeg_codec_parameters_t *parameters;
+  err = js_create_arraybuffer(env, parameters, handle);
+  assert(err == 0);
+
+  parameters->handle = avcodec_parameters_alloc();
+
+  return handle;
+}
+
+static void
+bare_ffmpeg_destroy_codec_parameters(
+  js_env_t *env,
+  js_receiver_t,
+  js_arraybuffer_span_of_t<bare_ffmpeg_codec_parameters_t, 1> parameters
+) {
+  avcodec_parameters_free(&parameters->handle);
+}
+
 static int64_t
 bare_ffmpeg_codec_parameters_get_bit_rate(
   js_env_t *env,
@@ -2875,6 +2901,8 @@ bare_ffmpeg_exports(js_env_t *env, js_value_t *exports) {
 
   V("codecParametersFromContext", bare_ffmpeg_codec_parameters_from_context)
   V("codecParametersToContext", bare_ffmpeg_codec_parameters_to_context)
+  V("createCodecParameters", bare_ffmpeg_create_codec_parameters)
+  V("destroyCodecParameters", bare_ffmpeg_destroy_codec_parameters)
   V("getCodecParametersBitRate", bare_ffmpeg_codec_parameters_get_bit_rate)
   V("setCodecParametersBitRate", bare_ffmpeg_codec_parameters_set_bit_rate)
   V("getCodecParametersBitsPerCodedSample", bare_ffmpeg_codec_parameters_get_bits_per_coded_sample)

--- a/lib/codec-parameters.js
+++ b/lib/codec-parameters.js
@@ -3,8 +3,9 @@ const ChannelLayout = require('./channel-layout')
 const Rational = require('./rational')
 
 module.exports = class FFmpegCodecParameters {
-  constructor(handle) {
+  constructor(handle, _detached = false) {
     this._handle = handle
+    this._detached = _detached
   }
 
   // Getters, Setters
@@ -196,6 +197,14 @@ module.exports = class FFmpegCodecParameters {
     binding.codecParametersToContext(context._handle, this._handle)
   }
 
+  destroy() {
+    if (this._detached) binding.destroyCodecParameters(this._handle)
+  }
+
+  [Symbol.dispose]() {
+    this.destroy()
+  }
+
   // TODO: add other props
   [Symbol.for('bare.inspect')]() {
     return {
@@ -220,5 +229,9 @@ module.exports = class FFmpegCodecParameters {
       trailingPadding: this.trailingPadding,
       seekPreroll: this.seekPreroll
     }
+  }
+
+  static alloc() {
+    return new FFmpegCodecParameters(binding.createCodecParameters(), true)
   }
 }

--- a/test/codec-parameters.js
+++ b/test/codec-parameters.js
@@ -214,6 +214,12 @@ test('CodecParameters class should expose a seekPreroll setter', (t) => {
   t.ok(codecParam.seekPreroll === 256)
 })
 
+test('create independent CodecParameters', (t) => {
+  const codecParam = ffmpeg.CodecParameters.alloc()
+
+  codecParam.destroy()
+})
+
 test.hook('teardown', () => {
   inputFormatContext.destroy()
 })

--- a/test/frame.js
+++ b/test/frame.js
@@ -12,7 +12,7 @@ test('frame expose a getter for width', (t) => {
   const fr = new ffmpeg.Frame()
   fr.width = 200
 
-  t.ok(fr.width == 200)
+  t.ok(fr.width === 200)
 })
 
 test('frame expose a setter for height', (t) => {
@@ -26,7 +26,7 @@ test('frame expose a getter for height', (t) => {
   const fr = new ffmpeg.Frame()
   fr.height = 200
 
-  t.ok(fr.height == 200)
+  t.ok(fr.height === 200)
 })
 
 test('frame expose a setter for pixelFormat', (t) => {
@@ -40,7 +40,7 @@ test('frame expose a getter for pixelFormat', (t) => {
   const fr = new ffmpeg.Frame()
   fr.pixelFormat = ffmpeg.constants.pixelFormats.YUV420P
 
-  t.ok(fr.pixelFormat == ffmpeg.constants.pixelFormats.YUV420P)
+  t.ok(fr.pixelFormat === ffmpeg.constants.pixelFormats.YUV420P)
 })
 
 test('frame expose an alloc method', (t) => {


### PR DESCRIPTION
In VCRCore the streams are virtual, but the `CodecParameters` should be real.

Being able to allocate independent CodecParameters (`avcodec_parameters_alloc()`) allows us to load value from a serialized format and configure a context without work-arounds.

```js
const params = CodecParameters.alloc()
// load with serialized values
params.id = Codec.OPUS.id
params.type = 1
params.format = sampleFormats.FLTP

const decoder = Codec.OPUS.decoder()
params.toContext(decoder) // <- reproduce context state
decoder.open()

params.destroy()
```

