### PR TITLE
add Dictionary.from(obj)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ for (const [key, value] of dict) {
 }
 ```
 
+#### Static methods
+
+##### `Dictionary.from(object)`
+
+A helper to create a `Dictionary` instance from an object.
+
+```js
+const dict = ffmpeg.Dictionary.from({
+  foo: 'bar',
+  baz: 'qux'
+})
+```
+
+**Returns**: A new `Dictionary` instance
+
 ### `FormatContext`
 
 The `FormatContext` API provides the base functionality for reading and writing media files.

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -1,6 +1,16 @@
 const binding = require('../binding')
 
 module.exports = class FFmpegDictionary {
+  static from(obj) {
+    const dictionary = new FFmpegDictionary()
+
+    for (const [key, value] of Object.entries(obj)) {
+      dictionary.set(key, value)
+    }
+
+    return dictionary
+  }
+
   constructor() {
     this._handle = binding.initDictionary()
   }

--- a/test/dictionary.js
+++ b/test/dictionary.js
@@ -65,3 +65,13 @@ test('it should expose an iterator', (t) => {
   t.is(result.at(1).key, 'boo')
   t.is(result.at(1).value, 'baz')
 })
+
+test('it should be created from an object', (t) => {
+  const dict = ffmpeg.Dictionary.from({
+    foo: 'bar',
+    boo: 'baz'
+  })
+
+  t.is(dict.get('foo'), 'bar')
+  t.is(dict.get('boo'), 'baz')
+})


### PR DESCRIPTION
A pr for a handy little helper to create a Dictionary instance from an object.

```js
const dict = ffmpeg.Dictionary.from({
  foo: 'bar',
  baz: 'qux'
})
````