### PR TITLE
reworked `IOContext` callbacks

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -222,11 +222,11 @@ bare_ffmpeg__on_io_context_seek(void *opaque, int64_t offset, int whence) {
   err = js_get_reference_value(env, context->on_seek, callback);
   assert(err == 0);
 
-  err = js_call_function(env, callback, offset, whence_str, result);
-  if (err < 0) return AVERROR(EIO);
+  err = js_call_function<js_type_options_t{}, int64_t, int64_t, std::string>(env, callback, offset, whence_str, result);
+  if (err < 0) return AVERROR(EIO); // read-error
 
   if (result == -1) {
-    return AVERROR(ENOSYS); // evals to 0??
+    return AVERROR(ENOSYS); // seek-op not supported by IO
   }
 
   return result;

--- a/lib/io-context.js
+++ b/lib/io-context.js
@@ -16,18 +16,11 @@ module.exports = class FFmpegIOContext {
       buffer = Buffer.alloc(0)
     }
 
-    let onwrite
-    if (opts.onwrite) {
-      onwrite = (chunk) => {
-        opts.onwrite(Buffer.from(chunk))
-      }
-    }
-
     this._handle = binding.initIOContext(
       buffer,
       offset,
       len,
-      onwrite,
+      opts.onwrite,
       opts.onread,
       opts.onseek
     )

--- a/test/io-context.js
+++ b/test/io-context.js
@@ -59,8 +59,20 @@ test('IOContext streaming mp4 with onseek', (t) => {
       offset += bytesToRead
       return bytesToRead
     },
-    onseek: (newOffset) => {
-      offset = Math.max(0, Math.min(newOffset, data.length))
+
+    onseek: (o, whence) => {
+      switch (whence) {
+        case 'avseek_size':
+          return data.length
+
+        case 'seek_set':
+          offset = o
+          return offset
+
+        default:
+          t.fail('seek operation not implemented: ' + whence)
+          return -1
+      }
     }
   })
 


### PR DESCRIPTION
- write_callback;  moved typedarray view from js wrapper to native
- read/seek: removed `context.offset` member as belongs to user IO implementation.
- seek: exposed seek-operation `whence` as a string.
- seek: returning `-1` signals that operation is not supported or not implemented.


@kasperisager just to be sure - i confirmed that the callbacks run on js-stack; but do we also need to surround the calls with open/close handle-scope?