### PR TITLE
reafactor(io-context): Use numeric literal for whence

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ const io = new ffmpeg.IOContext(4096, {
     switch (whence) {
       case ffmpeg.constants.seek.SIZE:
         return data.length
-      case ffmpeg.constants.seek.SEEK_SET:
+      case ffmpeg.constants.seek.SET:
         offset = offset
         return offset
       default:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ const io = new ffmpeg.IOContext(4096, {
   },
   onseek: (offset, whence) => {
     switch (whence) {
-      case ffmpeg.constants.seek.AVSEEK_SIZE:
+      case ffmpeg.constants.seek.SIZE:
         return data.length
       case ffmpeg.constants.seek.SEEK_SET:
         offset = offset

--- a/README.md
+++ b/README.md
@@ -10,19 +10,59 @@ npm i bare-ffmpeg
 
 ### `IOContext`
 
-The `IOContext` API provides functionality to create input/output contexts for media files.
+The `IOContext` API provides functionality to create input/output contexts for media files with support for streaming and custom I/O operations.
 
 ```js
-const io = new ffmpeg.IOContext(buffer)
+const io = new ffmpeg.IOContext(buffer[, options])
 ```
 
 Parameters:
 
-- `buffer` (`Buffer`): The media data buffer
+- `buffer` (`Buffer` | `number`): The media data buffer or buffer size for streaming
+- `options` (`object`, optional): Configuration options
+  - `onread` (`function`): A function for refilling the buffer.
+  - `onwrite` (`function`): A function for writing the buffer contents.
+  - `onseek` (`function`): A function for seeking to specified byte position.
 
 **Returns**: A new `IOContext` instance
 
-Example:
+#### Constructor Options
+
+##### `onread(buffer, requestedLen)`
+
+Callback function called when FFmpeg needs to read data. For streaming scenarios where data is not available in a single buffer.
+
+Parameters:
+
+- `buffer` (`Buffer`): Buffer to fill with data
+- `requestedLen` (`number`): Number of bytes requested
+
+**Returns**: `number` - Number of bytes actually read, or 0 for EOF
+
+##### `onwrite(buffer)`
+
+Callback function called when FFmpeg needs to write data. For streaming output scenarios.
+
+Parameters:
+
+- `buffer` (`Buffer`): Buffer containing data to write
+
+**Returns**: `number` - Number of bytes written
+
+##### `onseek(offset, whence)`
+
+Callback function called when FFmpeg needs to seek within the data source.
+
+Parameters:
+
+- `offset` (`number`): Offset to seek to
+- `whence` (`number`): Seek mode (see `ffmpeg.constants.seek`)
+
+**Returns**: `number` - New position or file size for `AVSEEK_SIZE`
+
+#### Examples
+
+**Basic usage with buffer:**
 
 ```js
 const image = require('./fixtures/image/sample.jpeg', {
@@ -30,6 +70,43 @@ const image = require('./fixtures/image/sample.jpeg', {
 })
 const io = new ffmpeg.IOContext(image)
 io.destroy()
+```
+
+**Streaming with custom read callback:**
+
+```js
+const io = new ffmpeg.IOContext(4096, {
+  onread: (buffer) => {
+    const bytesToRead = Math.min(buffer.length, data.length - offset)
+    if (bytesToRead === 0) return 0
+
+    const chunk = data.subarray(offset, offset + bytesToRead)
+    buffer.set(chunk)
+    offset += bytesToRead
+    return bytesToRead
+  }
+})
+```
+
+**Streaming with seek support:**
+
+```js
+const io = new ffmpeg.IOContext(4096, {
+  onread: (buffer) => {
+    // ... read implementation
+  },
+  onseek: (offset, whence) => {
+    switch (whence) {
+      case ffmpeg.constants.seek.AVSEEK_SIZE:
+        return data.length
+      case ffmpeg.constants.seek.SEEK_SET:
+        offset = offset
+        return offset
+      default:
+        return -1
+    }
+  }
+})
 ```
 
 #### Methods

--- a/binding.cc
+++ b/binding.cc
@@ -189,7 +189,13 @@ bare_ffmpeg__on_io_context_seek(void *opaque, int64_t offset, int whence) {
   int err = js_get_reference_value(env, context->on_seek, callback);
   assert(err == 0);
 
-  err = js_call_function(env, callback, offset, whence, result);
+  err = js_call_function<
+    js_type_options_t{},
+    int64_t,
+    int64_t,
+    int>(
+    env, callback, offset, whence, result
+  );
   if (err < 0) return AVERROR(EIO); // read-error
 
   if (result == -1) {
@@ -3399,6 +3405,7 @@ bare_ffmpeg_exports(js_env_t *env, js_value_t *exports) {
   V(AV_LEVEL_UNKNOWN)
 
   // SEEK
+  V(AVSEEK_SIZE)
   V(AVSEEK_FORCE)
   V(SEEK_CUR)
   V(SEEK_SET)

--- a/binding.cc
+++ b/binding.cc
@@ -1,4 +1,3 @@
-#include <cstdio>
 #include <tuple>
 #include <vector>
 
@@ -3400,7 +3399,6 @@ bare_ffmpeg_exports(js_env_t *env, js_value_t *exports) {
   V(AV_LEVEL_UNKNOWN)
 
   // SEEK
-  V(AVSEEK_SIZE)
   V(AVSEEK_FORCE)
   V(SEEK_CUR)
   V(SEEK_SET)

--- a/binding.cc
+++ b/binding.cc
@@ -1,3 +1,4 @@
+#include <cstdio>
 #include <tuple>
 #include <vector>
 
@@ -35,7 +36,7 @@ extern "C" {
 
 using bare_ffmpeg_io_context_write_cb_t = js_function_t<void, js_arraybuffer_t>;
 using bare_ffmpeg_io_context_read_cb_t = js_function_t<int32_t, js_arraybuffer_t, int32_t>;
-using bare_ffmpeg_io_context_seek_cb_t = js_function_t<int64_t, int64_t, std::string>;
+using bare_ffmpeg_io_context_seek_cb_t = js_function_t<int64_t, int64_t, int>;
 
 typedef struct {
   AVIOContext *handle;
@@ -181,39 +182,15 @@ bare_ffmpeg__on_io_context_read(void *opaque, uint8_t *buf, int len) {
 
 static int64_t
 bare_ffmpeg__on_io_context_seek(void *opaque, int64_t offset, int whence) {
-  int err;
-
   auto context = reinterpret_cast<bare_ffmpeg_io_context_t *>(opaque);
-
   auto env = context->env;
 
   int64_t result;
-  std::string whence_str;
-  switch (whence) {
-  case AVSEEK_SIZE:
-    whence_str = "avseek_size";
-    break;
-  case AVSEEK_FORCE:
-    whence_str = "avseek_force";
-    break;
-  case SEEK_SET:
-    whence_str = "seek_set";
-    break;
-  case SEEK_CUR:
-    whence_str = "seek_cur";
-    break;
-  case SEEK_END:
-    whence_str = "seek_end";
-    break;
-  default:
-    whence_str = "unknown:" + std::to_string(whence);
-  }
-
   bare_ffmpeg_io_context_seek_cb_t callback;
-  err = js_get_reference_value(env, context->on_seek, callback);
+  int err = js_get_reference_value(env, context->on_seek, callback);
   assert(err == 0);
 
-  err = js_call_function<js_type_options_t{}, int64_t, int64_t, std::string>(env, callback, offset, whence_str, result);
+  err = js_call_function(env, callback, offset, whence, result);
   if (err < 0) return AVERROR(EIO); // read-error
 
   if (result == -1) {
@@ -3421,6 +3398,13 @@ bare_ffmpeg_exports(js_env_t *env, js_value_t *exports) {
 
   // Levels
   V(AV_LEVEL_UNKNOWN)
+
+  // SEEK
+  V(AVSEEK_SIZE)
+  V(AVSEEK_FORCE)
+  V(SEEK_CUR)
+  V(SEEK_SET)
+  V(SEEK_END)
 #undef V
 
   return exports;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -135,11 +135,11 @@ module.exports = exports = {
     NOTIMESTAMPS: binding.AVFMT_NOTIMESTAMPS
   },
   seek: {
-    AVSEEK_SIZE: binding.AVSEEK_SIZE,
-    AVSEEK_FORCE: binding.AVSEEK_FORCE,
-    SEEK_CUR: binding.SEEK_CUR,
-    SEEK_SET: binding.SEEK_SET,
-    SEEK_END: binding.SEEK_END
+    SIZE: binding.AVSEEK_SIZE,
+    FORCE: binding.AVSEEK_FORCE,
+    CUR: binding.SEEK_CUR,
+    SET: binding.SEEK_SET,
+    END: binding.SEEK_END
   }
 }
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -133,6 +133,13 @@ module.exports = exports = {
     NOFILE: binding.AVFMT_NOFILE,
     NEEDNUMBER: binding.AVFMT_NEEDNUMBER,
     NOTIMESTAMPS: binding.AVFMT_NOTIMESTAMPS
+  },
+  seek: {
+    AVSEEK_SIZE: binding.AVSEEK_SIZE,
+    AVSEEK_FORCE: binding.AVSEEK_FORCE,
+    SEEK_CUR: binding.SEEK_CUR,
+    SEEK_SET: binding.SEEK_SET,
+    SEEK_END: binding.SEEK_END
   }
 }
 

--- a/test/io-context.js
+++ b/test/io-context.js
@@ -62,10 +62,10 @@ test('IOContext streaming mp4 with onseek', (t) => {
 
     onseek: (o, whence) => {
       switch (whence) {
-        case ffmpeg.constants.seek.AVSEEK_SIZE:
+        case ffmpeg.constants.seek.SIZE:
           return data.length
 
-        case ffmpeg.constants.seek.SEEK_SET:
+        case ffmpeg.constants.seek.SET:
           offset = o
           return offset
 

--- a/test/io-context.js
+++ b/test/io-context.js
@@ -31,16 +31,8 @@ test('IOContext streaming webm with onread', (t) => {
 
   const { audio, video } = runStreams(io)
 
-  t.is(
-    video.length,
-    145416,
-    `video size mismatch: got ${video.length}, expected 145416`
-  )
-  t.is(
-    audio.length,
-    42419,
-    `audio size mismatch: got ${audio.length}, expected 42419`
-  )
+  t.is(video.length, 145416, `video size: got ${video.length}, expected 145416`)
+  t.is(audio.length, 42419, `audio size: got ${audio.length}, expected 42419`)
 })
 
 test('IOContext streaming mp4 with onseek', (t) => {
@@ -70,10 +62,10 @@ test('IOContext streaming mp4 with onseek', (t) => {
 
     onseek: (o, whence) => {
       switch (whence) {
-        case 'avseek_size':
+        case ffmpeg.constants.seek.AVSEEK_SIZE:
           return data.length
 
-        case 'seek_set':
+        case ffmpeg.constants.seek.SEEK_SET:
           offset = o
           return offset
 
@@ -86,16 +78,8 @@ test('IOContext streaming mp4 with onseek', (t) => {
 
   const { audio, video } = runStreams(io)
 
-  t.is(
-    video.length,
-    140102,
-    `video size mismatch: got ${video.length}, expected 140102`
-  )
-  t.is(
-    audio.length,
-    34914,
-    `audio size mismatch: got ${audio.length}, expected 34914`
-  )
+  t.is(video.length, 140102, `video size: got ${video.length}, expected 140102`)
+  t.is(audio.length, 34914, `audio size: got ${audio.length}, expected 34914`)
 })
 
 function runStreams(io) {


### PR DESCRIPTION
+ doc update.

Fix #108 