### PR TITLE
resizeable `ffmpeg.Samples`

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -3323,7 +3323,7 @@ bare_ffmpeg_exports(js_env_t *env, js_value_t *exports) {
   V("readImage", bare_ffmpeg_image_read)
   V("getImageLineSize", bare_ffmpeg_image_get_line_size)
 
-  V("sizeofSamples", bare_ffmpeg_samples_buffer_size)
+  V("samplesBufferSize", bare_ffmpeg_samples_buffer_size)
   V("fillSamples", bare_ffmpeg_samples_fill)
 
   V("initPacket", bare_ffmpeg_packet_init)

--- a/binding.cc
+++ b/binding.cc
@@ -2262,7 +2262,7 @@ bare_ffmpeg_samples_fill(
     throw js_pending_exception;
   }
 
-  if (required < len) {
+  if (len < required) {
     js_throw_errorf(env, NULL, "required at least %zu bytes, got %zu", required, len);
 
     throw js_pending_exception;

--- a/binding.cc
+++ b/binding.cc
@@ -2889,7 +2889,6 @@ bare_ffmpeg_resampler_convert_frames(
     throw js_pending_exception;
   }
 
-
   return result;
 }
 

--- a/binding.cc
+++ b/binding.cc
@@ -2241,33 +2241,8 @@ bare_ffmpeg_samples_fill(
   js_arraybuffer_span_of_t<bare_ffmpeg_frame_t, 1> frame,
   js_arraybuffer_span_t target,
   uint64_t offset,
-  uint64_t len,
   bool no_alignment
 ) {
-  int err;
-  assert(target.size() >= offset + len);
-
-  auto required = av_samples_get_buffer_size(
-    NULL,
-    frame->handle->ch_layout.nb_channels,
-    frame->handle->nb_samples,
-    static_cast<AVSampleFormat>(frame->handle->format),
-    no_alignment
-  );
-
-  if (required < 0) {
-    err = js_throw_error(env, NULL, av_err2str(len));
-    assert(err == 0);
-
-    throw js_pending_exception;
-  }
-
-  if (len < required) {
-    js_throw_errorf(env, NULL, "required at least %zu bytes, got %zu", required, len);
-
-    throw js_pending_exception;
-  }
-
   auto res = av_samples_fill_arrays(
     frame->handle->data,
     frame->handle->linesize,
@@ -2279,7 +2254,7 @@ bare_ffmpeg_samples_fill(
   );
 
   if (res < 0) {
-    err = js_throw_error(env, NULL, av_err2str(len));
+    int err = js_throw_error(env, NULL, av_err2str(res));
     assert(err == 0);
 
     throw js_pending_exception;

--- a/binding.cc
+++ b/binding.cc
@@ -2889,7 +2889,6 @@ bare_ffmpeg_resampler_convert_frames(
     throw js_pending_exception;
   }
 
-  out_frame->handle->nb_samples = result;
 
   return result;
 }

--- a/binding.cc
+++ b/binding.cc
@@ -2205,8 +2205,8 @@ bare_ffmpeg_image_get_line_size(
   );
 }
 
-static uint32_t
-bare_ffmpeg_samples_sizeof(
+static int
+bare_ffmpeg_samples_buffer_size(
   js_env_t *env,
   js_receiver_t,
   int32_t sample_format,
@@ -2214,8 +2214,6 @@ bare_ffmpeg_samples_sizeof(
   int32_t nb_samples,
   bool no_alignment
 ) {
-  int err;
-
   auto len = av_samples_get_buffer_size(
     NULL,
     nb_channels,
@@ -2225,13 +2223,13 @@ bare_ffmpeg_samples_sizeof(
   );
 
   if (len < 0) {
-    err = js_throw_error(env, NULL, av_err2str(len));
+    int err = js_throw_error(env, NULL, av_err2str(len));
     assert(err == 0);
 
     throw js_pending_exception;
   }
 
-  return static_cast<uint32_t>(len);
+  return len;
 }
 
 static int
@@ -3325,7 +3323,7 @@ bare_ffmpeg_exports(js_env_t *env, js_value_t *exports) {
   V("readImage", bare_ffmpeg_image_read)
   V("getImageLineSize", bare_ffmpeg_image_get_line_size)
 
-  V("sizeofSamples", bare_ffmpeg_samples_sizeof)
+  V("sizeofSamples", bare_ffmpeg_samples_buffer_size)
   V("fillSamples", bare_ffmpeg_samples_fill)
 
   V("initPacket", bare_ffmpeg_packet_init)

--- a/lib/samples.js
+++ b/lib/samples.js
@@ -35,7 +35,7 @@ module.exports = class FFmpegSamples {
   fill(frame) {
     const { format, channelLayout, nbSamples } = frame
 
-    const len = FFmpegSamples.sizeOf(
+    const len = FFmpegSamples.bufferSize(
       format,
       channelLayout.nbChannels,
       nbSamples,
@@ -58,7 +58,7 @@ module.exports = class FFmpegSamples {
     return res
   }
 
-  static sizeOf(format, nbChannels, nbSamples, noAlignment = false) {
-    return binding.sizeofSamples(format, nbChannels, nbSamples, noAlignment)
+  static bufferSize(format, nbChannels, nbSamples, noAlignment = false) {
+    return binding.samplesBufferSize(format, nbChannels, nbSamples, noAlignment)
   }
 }

--- a/lib/samples.js
+++ b/lib/samples.js
@@ -1,49 +1,63 @@
 const binding = require('../binding')
-const constants = require('./constants.js')
 
 module.exports = class FFmpegSamples {
-  constructor(sampleFormat, nbChannels, nbSamples, align = 0) {
-    sampleFormat = constants.toSampleFormat(sampleFormat)
+  _data
+  #lastKnown = {}
 
-    this._sampleFormat = sampleFormat
-    this._nbChannels = nbChannels
-    this._nbSamples = nbSamples
-    this._align = align
-
-    this._data = Buffer.from(
-      binding.initSamples(sampleFormat, nbChannels, nbSamples, align)
-    )
-  }
-
-  get sampleFormat() {
-    return this._sampleFormat
-  }
-
-  get nbChannels() {
-    return this._nbChannels
-  }
-
-  get nbSamples() {
-    return this._nbSamples
-  }
-
-  get align() {
-    return this._align
+  constructor({ noAlignment = false } = {}) {
+    this._noAlignment = noAlignment
   }
 
   get data() {
     return this._data
   }
 
+  get format() {
+    return this.#lastKnown.format
+  }
+
+  get channelLayout() {
+    return this.#lastKnown.channelLayout
+  }
+
+  get nbSamples() {
+    return this.#lastKnown.nbSamples
+  }
+
+  get nbChannels() {
+    return this.channelLayout && this.channelLayout.nbChannels
+  }
+
   fill(frame) {
+    const { format, channelLayout, nbSamples } = frame
+    this.#lastKnown = { format, channelLayout, nbSamples }
+
+    const len = FFmpegSamples.sizeOf(
+      format,
+      channelLayout.nbChannels,
+      nbSamples,
+      this._noAlignment
+    )
+
+    let reallocated = false
+
+    if (!this._data || len !== this._data.length) {
+      this._data = Buffer.allocUnsafe(len)
+      reallocated = true
+    }
+
     binding.fillSamples(
-      this._sampleFormat,
-      this._nbChannels,
-      this._nbSamples,
-      this._align,
+      frame._handle,
       this._data.buffer,
       this._data.byteOffset,
-      frame._handle
+      this._data.byteLength,
+      this._noAlignment
     )
+
+    return reallocated
+  }
+
+  static sizeOf(format, nbChannels, nbSamples, noAlignment = false) {
+    return binding.sizeofSamples(format, nbChannels, nbSamples, noAlignment)
   }
 }

--- a/lib/samples.js
+++ b/lib/samples.js
@@ -53,7 +53,6 @@ module.exports = class FFmpegSamples {
       frame._handle,
       this._data.buffer,
       this._data.byteOffset,
-      this._data.byteLength,
       this._noAlignment
     )
 

--- a/lib/samples.js
+++ b/lib/samples.js
@@ -42,14 +42,11 @@ module.exports = class FFmpegSamples {
       this._noAlignment
     )
 
-    let reallocated = false
-
     if (!this._data || len !== this._data.length) {
       this._data = Buffer.allocUnsafe(len)
-      reallocated = true
     }
 
-    binding.fillSamples(
+    const res = binding.fillSamples(
       frame._handle,
       this._data.buffer,
       this._data.byteOffset,
@@ -58,7 +55,7 @@ module.exports = class FFmpegSamples {
 
     this._frame = frame
 
-    return reallocated
+    return res
   }
 
   static sizeOf(format, nbChannels, nbSamples, noAlignment = false) {

--- a/lib/samples.js
+++ b/lib/samples.js
@@ -2,7 +2,7 @@ const binding = require('../binding')
 
 module.exports = class FFmpegSamples {
   _data
-  #lastKnown = {}
+  _frame
 
   constructor({ noAlignment = false } = {}) {
     this._noAlignment = noAlignment
@@ -13,24 +13,27 @@ module.exports = class FFmpegSamples {
   }
 
   get format() {
-    return this.#lastKnown.format
+    return this._frame.format
   }
 
   get channelLayout() {
-    return this.#lastKnown.channelLayout
+    return this._frame.channelLayout
   }
 
   get nbSamples() {
-    return this.#lastKnown.nbSamples
+    return this._frame.nbSamples
   }
 
   get nbChannels() {
     return this.channelLayout && this.channelLayout.nbChannels
   }
 
+  get pts() {
+    return this._frame.pts
+  }
+
   fill(frame) {
     const { format, channelLayout, nbSamples } = frame
-    this.#lastKnown = { format, channelLayout, nbSamples }
 
     const len = FFmpegSamples.sizeOf(
       format,
@@ -53,6 +56,8 @@ module.exports = class FFmpegSamples {
       this._data.byteLength,
       this._noAlignment
     )
+
+    this._frame = frame
 
     return reallocated
   }

--- a/test/decode.js
+++ b/test/decode.js
@@ -153,7 +153,7 @@ function decodeAudio(audio) {
         output.nbSamples = raw.nbSamples
         output.sampleRate = stream.codecParameters.sampleRate
 
-        const samples = new ffmpeg.Samples('S16', 2, output.nbSamples)
+        const samples = new ffmpeg.Samples()
         samples.fill(output)
 
         resampler.convert(raw, output)
@@ -168,11 +168,7 @@ function decodeAudio(audio) {
     output.format = ffmpeg.constants.sampleFormats.S16
     output.nbSamples = 1024
 
-    const samples = new ffmpeg.Samples(
-      output.format,
-      output.channelLayout.nbChannels,
-      output.nbSamples
-    )
+    const samples = new ffmpeg.Samples()
     samples.fill(output)
 
     while (resampler.flush(output) > 0) {


### PR DESCRIPTION
There is no guarantee that `decoder.receiveFrame(frame)` produces constant frame-sizes (`nbSamples` may vary).

So I changed the Samples api to contain less state:

- `bare_ffmpeg_samples_init()` removed; replaced with static function `Samples.sizeOf()`
- `new Samples()` constructor takes only the `noAlignment` option.
- `samples.fill(frame)` changes:
  - Reallocates `data` buffer to match size of `frame` when necessary
  - All required values are safely read from `frame`
