### PR TITLE
ld: building for 'iOS', but linking in dylib built for macOS macCatalyst

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -1,0 +1,3 @@
+exports.getOption = function getOption(handle, name, flags) {
+  return binding.getOption(handle, name, flags)
+}


### PR DESCRIPTION
first saw this linker error in #147 

```
[38/38] Linking CXX shared library bare-ffmpeg@1.bare
FAILED: [code=1] bare-ffmpeg@1.bare 
: && /opt/homebrew/opt/llvm@18/bin/clang++ --target=arm64-apple-ios14.0 -g -isysroot /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk -miphoneos-version-min=14.0 -dynamiclib -Wl,-headerpad_max_install_names -Wl,-undefined,dynamic_lookup -compatibility_version 1.0.0 -current_version 1.0.0 -o bare-ffmpeg@1.bare -install_name bare-ffmpeg@1.bare CMakeFiles/bare-ffmpeg-1.0.0-27-eb387f31.dir/binding.cc.o  _ports/github+FFmpeg+FFmpeg/lib/libavdevice.a  _ports/github+FFmpeg+FFmpeg/lib/libavfilter.a  -framework AVFoundation  -framework CoreAudio  -framework CoreGraphics  -framework Foundation  _ports/github+FFmpeg+FFmpeg/lib/libavformat.a  _ports/github+FFmpeg+FFmpeg/lib/libavcodec.a  _ports/git+code.videolan.org+videolan+dav1d/lib/libdav1d.a  _ports/gitlab+AOMediaCodec+SVT-AV1/lib/libSvtAv1Enc.a  _ports/github+xiph+opus/lib/libopus.a  _ports/github+FFmpeg+FFmpeg/lib/libswresample.a  _ports/github+FFmpeg+FFmpeg/lib/libswscale.a  _ports/github+FFmpeg+FFmpeg/lib/libavutil.a  -framework VideoToolbox  -framework CoreFoundation  -framework CoreMedia  -framework CoreVideo  -framework CoreServices && :
ld: warning: -undefined dynamic_lookup is deprecated on iOS
ld: warning: -undefined dynamic_lookup is deprecated on iOS
ld: building for 'iOS', but linking in dylib (/Library/Developer/CommandLineTools/SDKs/MacOSX15.5.sdk/System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation.tbd) built for 'macOS macCatalyst zippered(macOS/Catalyst)'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
Error: Process completed with exit code 1.
```