### PR TITLE
dumb down time scale ops

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -193,6 +193,14 @@ module.exports = exports = {
     CHANNEL_LAYOUT: binding.AV_CODEC_CONFIG_CHANNEL_LAYOUT,
     COLOR_RANGE: binding.AV_CODEC_CONFIG_COLOR_RANGE,
     COLOR_SPACE: binding.AV_CODEC_CONFIG_COLOR_SPACE
+  },
+  rounding: {
+    AV_ROUND_ZERO: binding.AV_ROUND_ZERO,
+    AV_ROUND_INF: binding.AV_ROUND_INF,
+    AV_ROUND_DOWN: binding.AV_ROUND_DOWN,
+    AV_ROUND_UP: binding.AV_ROUND_UP,
+    AV_ROUND_NEAR_INF: binding.AV_ROUND_NEAR_INF,
+    AV_ROUND_PASS_MINMAX: binding.AV_ROUND_PASS_MINMAX
   }
 }
 

--- a/lib/packet.js
+++ b/lib/packet.js
@@ -130,11 +130,13 @@ module.exports = class FFmpegPacket {
     binding.setPacketTimeBase(this._handle, value.numerator, value.denominator)
   }
 
-  rescaleTimestamps(rational) {
+  rescaleTimestamps(srcTimeBase, dstTimeBase) {
     return binding.rescalePacketTimestamps(
       this._handle,
-      rational.numerator,
-      rational.denominator
+      srcTimeBase.numerator,
+      srcTimeBase.denominator,
+      dstTimeBase.numerator,
+      dstTimeBase.denominator
     )
   }
 

--- a/lib/rational.js
+++ b/lib/rational.js
@@ -1,4 +1,5 @@
 const binding = require('../binding')
+const { AV_ROUND_NEAR_INF } = require('./constants').rounding
 
 module.exports = class FFmpegRational {
   constructor(numerator = 0, denominator = 1) {
@@ -38,7 +39,7 @@ module.exports = class FFmpegRational {
     return new FFmpegRational(view[0], view[1])
   }
 
-  static rescaleQ(n, src, dst) {
+  static rescaleQ(n, src, dst, round = AV_ROUND_NEAR_INF) {
     if (src.equals(dst)) return n
 
     return binding.rationalRescaleQ(
@@ -46,7 +47,8 @@ module.exports = class FFmpegRational {
       src.numerator,
       src.denominator,
       dst.numerator,
-      dst.denominator
+      dst.denominator,
+      round
     )
   }
 }

--- a/test/packet.js
+++ b/test/packet.js
@@ -127,16 +127,14 @@ test('rescale packet timestamps & timebase', (t) => {
 
   packet.dts = ts
   packet.pts = ts
-  packet.timeBase = new ffmpeg.Rational(1, 1000)
+  const src = new ffmpeg.Rational(1, 1000)
 
   const dst = new ffmpeg.Rational(1, 100)
 
-  const success = packet.rescaleTimestamps(dst)
-  t.ok(success)
+  packet.rescaleTimestamps(src, dst)
 
   t.is(packet.dts, packet.pts)
   t.is(packet.dts, 700)
-  t.alike(packet.timeBase, dst)
 })
 
 test('packet should expose a sideData getter', (t) => {


### PR DESCRIPTION
`packet->time_base` is mostly unused by ffmpeg;
so this patch mirrors the C-api.