### PR TITLE
refactor(format-context): remove io ownership

### DIFF
--- a/docs/input-format-context.md
+++ b/docs/input-format-context.md
@@ -10,8 +10,8 @@ const format = new ffmpeg.InputFormatContext(io, options[, url])
 
 ### Parameters
 
-- `io` (`IOContext` | `InputFormat`): The IO context or input format. The ownership of `io` is transferred.
-- `options` (`Dictionary`): Format options. Required when using `InputFormat`, ignored when using `IOContext`. The ownership of `options` is transferred.
+- `io` (`IOContext` | `InputFormat`): The IO context or input format.
+- `options` (`Dictionary`): Format options. Required when using `InputFormat`, ignored when using `IOContext`.
 - `url` (`string`, optional): Media source URL. Defaults to a platform-specific value
 
 **Returns**: A new `InputFormatContext` instance

--- a/docs/io-context.md
+++ b/docs/io-context.md
@@ -60,8 +60,7 @@ Callback function called when FFmpeg needs to seek within the data source.
 const image = require('./fixtures/image/sample.jpeg', {
   with: { type: 'binary' }
 })
-const io = new ffmpeg.IOContext(image)
-io.destroy()
+using io = new ffmpeg.IOContext(image)
 ```
 
 ### Streaming with custom read callback

--- a/docs/output-format-context.md
+++ b/docs/output-format-context.md
@@ -11,7 +11,7 @@ const format = new ffmpeg.OutputFormatContext(formatName, io)
 ### Parameters
 
 - `formatName` (`string`): The output format name (e.g., `'mp4'`, `'avi'`)
-- `io` (`IOContext`): The IO context for writing. The ownership of `io` is transferred.
+- `io` (`IOContext`): The IO context for writing.
 
 **Returns**: A new `OutputFormatContext` instance
 

--- a/lib/format-context.js
+++ b/lib/format-context.js
@@ -13,10 +13,7 @@ class FFmpegFormatContext {
   }
 
   destroy() {
-    if (this._io) {
-      this._io.destroy()
-      this._io = null
-    }
+    this._io = null
   }
 
   get io() {

--- a/test/decode.js
+++ b/test/decode.js
@@ -87,7 +87,7 @@ test('decode .webm', (t) => {
 })
 
 function decodeImage(image) {
-  const io = new ffmpeg.IOContext(image)
+  using io = new ffmpeg.IOContext(image)
   using format = new ffmpeg.InputFormatContext(io)
 
   let result
@@ -123,7 +123,7 @@ function decodeImage(image) {
 }
 
 function decodeAudio(audio) {
-  const io = new ffmpeg.IOContext(audio)
+  using io = new ffmpeg.IOContext(audio)
   using format = new ffmpeg.InputFormatContext(io)
 
   let result
@@ -189,7 +189,7 @@ function decodeAudio(audio) {
 }
 
 function decodeVideo(video) {
-  const io = new ffmpeg.IOContext(video)
+  using io = new ffmpeg.IOContext(video)
   using format = new ffmpeg.InputFormatContext(io)
 
   using packet = new ffmpeg.Packet()

--- a/test/format-context.js
+++ b/test/format-context.js
@@ -10,8 +10,7 @@ test('InputFormatContext should be instantiate with IOContext', (t) => {
   const image = require('./fixtures/image/sample.jpeg', {
     with: { type: 'binary' }
   })
-  const io = new ffmpeg.IOContext(image)
-
+  using io = new ffmpeg.IOContext(image)
   using inputFormatContext = new ffmpeg.InputFormatContext(io)
 
   t.ok(inputFormatContext)
@@ -76,8 +75,8 @@ test('InputFormatContext.inputFormat should expose a inputFormat getter', (t) =>
 // OutputFormatContext
 
 test('OutputFormatContext should expose an outputFormat getter', (t) => {
-  const io = new ffmpeg.IOContext(4096)
-  const outContext = new ffmpeg.OutputFormatContext(new ffmpeg.OutputFormat('webm'), io)
+  using io = new ffmpeg.IOContext(4096)
+  using outContext = new ffmpeg.OutputFormatContext(new ffmpeg.OutputFormat('webm'), io)
 
   const outputFormat = outContext.outputFormat
 

--- a/test/io-context.js
+++ b/test/io-context.js
@@ -5,7 +5,7 @@ const { mediaTypes } = ffmpeg.constants
 
 test('IOContext should propagate onread throwed error properly', (t) => {
   const readError = 'read error'
-  const io = new ffmpeg.IOContext(4096, {
+  using io = new ffmpeg.IOContext(4096, {
     onread: () => {
       throw new Error(readError)
     }
@@ -26,7 +26,7 @@ test('IOContext should propagate onseek throwed error properly', (t) => {
   const seekError = 'seek error'
 
   let offset = 0
-  const io = new ffmpeg.IOContext(4096, {
+  using io = new ffmpeg.IOContext(4096, {
     onread: (buffer) => {
       const remaining = data.length - offset
       if (remaining <= 0) return 0
@@ -51,7 +51,7 @@ test('IOContext should propagate onseek throwed error properly', (t) => {
 
 test('IOContext should propagate onwrite throwed error properly', (t) => {
   const writeError = 'write error'
-  const io = new ffmpeg.IOContext(4096, {
+  using io = new ffmpeg.IOContext(4096, {
     onwrite: () => {
       throw new Error(writeError)
     }
@@ -80,7 +80,7 @@ test('IOContext streaming webm with onread', (t) => {
   })
 
   let offset = 0
-  const io = new ffmpeg.IOContext(4096, {
+  using io = new ffmpeg.IOContext(4096, {
     onread: (buffer) => {
       if (!offset) {
         t.ok(Buffer.isBuffer(buffer), 'is buffer')
@@ -112,7 +112,7 @@ test('IOContext streaming mp4 with onseek', (t) => {
   })
 
   let offset = 0
-  const io = new ffmpeg.IOContext(4096, {
+  using io = new ffmpeg.IOContext(4096, {
     onread: (buffer) => {
       if (!offset) {
         t.ok(Buffer.isBuffer(buffer), 'is buffer')

--- a/test/packet.js
+++ b/test/packet.js
@@ -230,8 +230,8 @@ function fillPacket(packet) {
   const image = require('./fixtures/image/sample.jpeg', {
     with: { type: 'binary' }
   })
-  const io = new ffmpeg.IOContext(image)
-  const format = new ffmpeg.InputFormatContext(io)
+  using io = new ffmpeg.IOContext(image)
+  using format = new ffmpeg.InputFormatContext(io)
   format.readFrame(packet)
 }
 

--- a/test/resampler.js
+++ b/test/resampler.js
@@ -107,8 +107,8 @@ test('resampler with audio from aiff file', (t) => {
   const audio = require('./fixtures/audio/sample.aiff', {
     with: { type: 'binary' }
   })
-  const io = new ffmpeg.IOContext(audio)
-  const format = new ffmpeg.InputFormatContext(io)
+  using io = new ffmpeg.IOContext(audio)
+  using format = new ffmpeg.InputFormatContext(io)
 
   for (const stream of format.streams) {
     const decoder = stream.decoder()
@@ -146,8 +146,6 @@ test('resampler with audio from aiff file', (t) => {
     decoder.destroy()
     resampler.destroy()
   }
-
-  format.destroy()
 })
 
 test('resampler converts between different sample formats', (t) => {
@@ -155,7 +153,7 @@ test('resampler converts between different sample formats', (t) => {
     with: { type: 'binary' }
   })
 
-  const io = new ffmpeg.IOContext(audio)
+  using io = new ffmpeg.IOContext(audio)
   using format = new ffmpeg.InputFormatContext(io)
   const stream = format.streams[0]
   using decoder = stream.decoder()

--- a/test/scaler.js
+++ b/test/scaler.js
@@ -6,7 +6,7 @@ test('it should preseve line number in case of downscale', (t) => {
     with: { type: 'binary' }
   })
 
-  const io = new ffmpeg.IOContext(image)
+  using io = new ffmpeg.IOContext(image)
   using format = new ffmpeg.InputFormatContext(io)
 
   for (const stream of format.streams) {
@@ -14,30 +14,28 @@ test('it should preseve line number in case of downscale', (t) => {
     format.readFrame(packet)
 
     using raw = new ffmpeg.Frame()
-    using rgba = new ffmpeg.Frame()
 
     using decoder = stream.decoder()
+    decoder.open()
     decoder.sendPacket(packet)
     decoder.receiveFrame(raw)
 
-    const targetWidth = decoder.width / 2
-    const targetHeight = decoder.height / 2
-
-    rgba.width = targetWidth
-    rgba.height = targetHeight
-    rgba.pixelFormat = ffmpeg.constants.pixelFormats.RGBA
+    using rgba = new ffmpeg.Frame()
+    rgba.width = decoder.width / 2
+    rgba.height = decoder.height / 2
+    rgba.format = ffmpeg.constants.pixelFormats.RGBA
     rgba.alloc()
 
     using scaler = new ffmpeg.Scaler(
       decoder.pixelFormat,
       decoder.width,
       decoder.height,
-      rgba.pixelFormat,
+      rgba.format,
       rgba.width,
       rgba.height
     )
     const lines = scaler.scale(raw, rgba)
 
-    t.ok(lines == targetHeight)
+    t.ok(lines == rgba.height)
   }
 })


### PR DESCRIPTION
## Context

I saw users shooting themselves into their feet because of this used case:


```js
  using io = new ffmpeg.IOContext(image)
  using inputFormatContext = new ffmpeg.InputFormatContext(io)
```

... which provokes a double free in the current implementation.

## Proposal

I would stand with the real `ffmpeg` implementation where you have to handle the memory of these objects on your own.

Another option could have been to set the object as `owned` when it is passed to `format-context` but it would add a layer a logic we should maintain.

## Impact

We would have to alter all our users to patch their code aiming to avoid leaks.