### PR TITLE
refactor(format-context): add transfer method

### DIFF
--- a/docs/input-format-context.md
+++ b/docs/input-format-context.md
@@ -10,7 +10,7 @@ const format = new ffmpeg.InputFormatContext(io, options[, url])
 
 ### Parameters
 
-- `io` (`IOContext` | `InputFormat`): The IO context or input format. When using `IOContext`, the native handle is transferred to the format context, making the original IOContext safe to destroy multiple times.
+- `io` (`IOContext` | `InputFormat`): The IO context or input format. When using `IOContext`, ownership is automatically transferred to the format context, making the original IOContext safe to destroy multiple times.
 - `options` (`Dictionary`): Format options. Required when using `InputFormat`, ignored when using `IOContext`. The ownership of `options` is transferred.
 - `url` (`string`, optional): Media source URL. Defaults to a platform-specific value
 

--- a/docs/input-format-context.md
+++ b/docs/input-format-context.md
@@ -10,7 +10,7 @@ const format = new ffmpeg.InputFormatContext(io, options[, url])
 
 ### Parameters
 
-- `io` (`IOContext` | `InputFormat`): The IO context or input format. The ownership of `io` is transferred.
+- `io` (`IOContext` | `InputFormat`): The IO context or input format. When using `IOContext`, the native handle is transferred to the format context, making the original IOContext safe to destroy multiple times.
 - `options` (`Dictionary`): Format options. Required when using `InputFormat`, ignored when using `IOContext`. The ownership of `options` is transferred.
 - `url` (`string`, optional): Media source URL. Defaults to a platform-specific value
 

--- a/docs/io-context.md
+++ b/docs/io-context.md
@@ -108,21 +108,16 @@ Destroys the `IOContext` and frees all associated resources. Automatically calle
 
 **Returns**: `void`
 
-### `IOContext.transfer(targetIOContext)`
+### `IOContext.transfer()`
 
-Transfers ownership from this IOContext to another IOContext. After transfer, this IOContext becomes inactive while the target takes full ownership. This enables safe ownership transfer between objects.
+Creates a new IOContext and transfers ownership from this IOContext to the new instance. After transfer, this IOContext becomes inactive while the returned IOContext has full ownership. This enables safe ownership transfer between objects.
 
-**Parameters:**
-
-- `targetIOContext` (`IOContext`): The IOContext instance to receive ownership
-
-**Returns**: `void`
+**Returns**: `IOContext` - A new IOContext instance with transferred ownership
 
 **Example:**
 
 ```js
 const sourceIO = new ffmpeg.IOContext(buffer)
-const targetIO = new ffmpeg.IOContext(null, null) // Empty IOContext
-sourceIO.transfer(targetIO)
+const targetIO = sourceIO.transfer()
 // sourceIO is now safe to destroy, targetIO has full ownership
 ```

--- a/docs/io-context.md
+++ b/docs/io-context.md
@@ -60,8 +60,7 @@ Callback function called when FFmpeg needs to seek within the data source.
 const image = require('./fixtures/image/sample.jpeg', {
   with: { type: 'binary' }
 })
-const io = new ffmpeg.IOContext(image)
-io.destroy()
+using io = new ffmpeg.IOContext(image)
 ```
 
 ### Streaming with custom read callback
@@ -105,6 +104,25 @@ const io = new ffmpeg.IOContext(4096, {
 
 ### `IOContext.destroy()`
 
-Destroys the `IOContext` and frees all associated resources. Automatically called when the object is managed by a `using` declaration.
+Destroys the `IOContext` and frees all associated resources. Automatically called when the object is managed by a `using` declaration. Safe to call multiple times - becomes a no-op after the native handle is transferred.
 
 **Returns**: `void`
+
+### `IOContext.transfer(targetIOContext)`
+
+Transfers ownership from this IOContext to another IOContext. After transfer, this IOContext becomes inactive while the target takes full ownership. This enables safe ownership transfer between objects.
+
+**Parameters:**
+
+- `targetIOContext` (`IOContext`): The IOContext instance to receive ownership
+
+**Returns**: `void`
+
+**Example:**
+
+```js
+const sourceIO = new ffmpeg.IOContext(buffer)
+const targetIO = new ffmpeg.IOContext(null, null) // Empty IOContext
+sourceIO.transfer(targetIO)
+// sourceIO is now safe to destroy, targetIO has full ownership
+```

--- a/docs/output-format-context.md
+++ b/docs/output-format-context.md
@@ -11,7 +11,7 @@ const format = new ffmpeg.OutputFormatContext(formatName, io)
 ### Parameters
 
 - `formatName` (`string`): The output format name (e.g., `'mp4'`, `'avi'`)
-- `io` (`IOContext`): The IO context for writing. The ownership of `io` is transferred.
+- `io` (`IOContext`): The IO context for writing. The native handle is transferred to the format context, making the original IOContext safe to destroy multiple times.
 
 **Returns**: A new `OutputFormatContext` instance
 

--- a/docs/output-format-context.md
+++ b/docs/output-format-context.md
@@ -11,7 +11,7 @@ const format = new ffmpeg.OutputFormatContext(formatName, io)
 ### Parameters
 
 - `formatName` (`string`): The output format name (e.g., `'mp4'`, `'avi'`)
-- `io` (`IOContext`): The IO context for writing. The native handle is transferred to the format context, making the original IOContext safe to destroy multiple times.
+- `io` (`IOContext`): The IO context for writing. Ownership is automatically transferred to the format context, making the original IOContext safe to destroy multiple times.
 
 **Returns**: A new `OutputFormatContext` instance
 

--- a/lib/format-context.js
+++ b/lib/format-context.js
@@ -8,9 +8,7 @@ const Dictionary = require('./dictionary')
 
 class FFmpegFormatContext {
   constructor(io) {
-    if (io) {
-      this._io = io.transfer()
-    }
+    this._io = io ? io.transfer() : null
     this._streams = []
   }
 

--- a/lib/format-context.js
+++ b/lib/format-context.js
@@ -8,7 +8,11 @@ const Dictionary = require('./dictionary')
 
 class FFmpegFormatContext {
   constructor(io) {
-    this._io = io
+    if (io) {
+      const ownedIO = new IOContext(null, null)
+      io.transfer(ownedIO)
+      this._io = ownedIO
+    }
     this._streams = []
   }
 
@@ -86,7 +90,7 @@ exports.InputFormatContext = class FFmpegInputFormatContext extends FFmpegFormat
     if (io instanceof IOContext) {
       super(io)
 
-      this._handle = binding.openInputFormatContextWithIO(io._handle)
+      this._handle = binding.openInputFormatContextWithIO(this._io._handle)
     } else if (io instanceof InputFormat) {
       super()
 
@@ -125,7 +129,7 @@ exports.OutputFormatContext = class FFmpegOutputFormatContext extends FFmpegForm
 
     if (typeof format === 'string') format = new OutputFormat(format)
 
-    this._handle = binding.openOutputFormatContext(format._handle, io._handle)
+    this._handle = binding.openOutputFormatContext(format._handle, this._io._handle)
     this._isOutput = true
   }
 

--- a/lib/format-context.js
+++ b/lib/format-context.js
@@ -9,9 +9,7 @@ const Dictionary = require('./dictionary')
 class FFmpegFormatContext {
   constructor(io) {
     if (io) {
-      const ownedIO = new IOContext(null, null)
-      io.transfer(ownedIO)
-      this._io = ownedIO
+      this._io = io.transfer()
     }
     this._streams = []
   }

--- a/lib/io-context.js
+++ b/lib/io-context.js
@@ -38,9 +38,11 @@ module.exports = class FFmpegIOContext {
     }
   }
 
-  transfer(to) {
+  transfer() {
+    const to = new FFmpegIOContext(null, null)
     to._handle = this._handle
     this._handle = null
+    return to
   }
 
   [Symbol.dispose]() {

--- a/lib/io-context.js
+++ b/lib/io-context.js
@@ -2,6 +2,11 @@ const binding = require('../binding')
 
 module.exports = class FFmpegIOContext {
   constructor(buffer, opts = {}) {
+    if (buffer === null && opts === null) {
+      this._handle = null
+      return
+    }
+
     let offset = 0
     let len = 0
 
@@ -27,7 +32,14 @@ module.exports = class FFmpegIOContext {
   }
 
   destroy() {
-    binding.destroyIOContext(this._handle)
+    if (this._handle) {
+      binding.destroyIOContext(this._handle)
+      this._handle = null
+    }
+  }
+
+  transfer(to) {
+    to._handle = this._handle
     this._handle = null
   }
 

--- a/test/decode.js
+++ b/test/decode.js
@@ -87,7 +87,7 @@ test('decode .webm', (t) => {
 })
 
 function decodeImage(image) {
-  const io = new ffmpeg.IOContext(image)
+  using io = new ffmpeg.IOContext(image)
   using format = new ffmpeg.InputFormatContext(io)
 
   let result
@@ -123,7 +123,7 @@ function decodeImage(image) {
 }
 
 function decodeAudio(audio) {
-  const io = new ffmpeg.IOContext(audio)
+  using io = new ffmpeg.IOContext(audio)
   using format = new ffmpeg.InputFormatContext(io)
 
   let result
@@ -189,7 +189,7 @@ function decodeAudio(audio) {
 }
 
 function decodeVideo(video) {
-  const io = new ffmpeg.IOContext(video)
+  using io = new ffmpeg.IOContext(video)
   using format = new ffmpeg.InputFormatContext(io)
 
   using packet = new ffmpeg.Packet()

--- a/test/format-context.js
+++ b/test/format-context.js
@@ -10,8 +10,7 @@ test('InputFormatContext should be instantiate with IOContext', (t) => {
   const image = require('./fixtures/image/sample.jpeg', {
     with: { type: 'binary' }
   })
-  const io = new ffmpeg.IOContext(image)
-
+  using io = new ffmpeg.IOContext(image)
   using inputFormatContext = new ffmpeg.InputFormatContext(io)
 
   t.ok(inputFormatContext)
@@ -76,8 +75,8 @@ test('InputFormatContext.inputFormat should expose a inputFormat getter', (t) =>
 // OutputFormatContext
 
 test('OutputFormatContext should expose an outputFormat getter', (t) => {
-  const io = new ffmpeg.IOContext(4096)
-  const outContext = new ffmpeg.OutputFormatContext(new ffmpeg.OutputFormat('webm'), io)
+  using io = new ffmpeg.IOContext(4096)
+  using outContext = new ffmpeg.OutputFormatContext(new ffmpeg.OutputFormat('webm'), io)
 
   const outputFormat = outContext.outputFormat
 

--- a/test/io-context.js
+++ b/test/io-context.js
@@ -158,9 +158,8 @@ test('IOContext.transfer() should transfer ownership between IOContext instances
     with: { type: 'binary' }
   })
   using sourceIO = new ffmpeg.IOContext(buffer)
-  using targetIO = new ffmpeg.IOContext(null, null)
 
-  sourceIO.transfer(targetIO)
+  using targetIO = sourceIO.transfer()
 
   using format = new ffmpeg.InputFormatContext(targetIO)
   t.ok(format, 'targetIO works after transfer')

--- a/test/io-context.js
+++ b/test/io-context.js
@@ -5,7 +5,7 @@ const { mediaTypes } = ffmpeg.constants
 
 test('IOContext should propagate onread throwed error properly', (t) => {
   const readError = 'read error'
-  const io = new ffmpeg.IOContext(4096, {
+  using io = new ffmpeg.IOContext(4096, {
     onread: () => {
       throw new Error(readError)
     }
@@ -26,7 +26,7 @@ test('IOContext should propagate onseek throwed error properly', (t) => {
   const seekError = 'seek error'
 
   let offset = 0
-  const io = new ffmpeg.IOContext(4096, {
+  using io = new ffmpeg.IOContext(4096, {
     onread: (buffer) => {
       const remaining = data.length - offset
       if (remaining <= 0) return 0
@@ -51,7 +51,7 @@ test('IOContext should propagate onseek throwed error properly', (t) => {
 
 test('IOContext should propagate onwrite throwed error properly', (t) => {
   const writeError = 'write error'
-  const io = new ffmpeg.IOContext(4096, {
+  using io = new ffmpeg.IOContext(4096, {
     onwrite: () => {
       throw new Error(writeError)
     }
@@ -80,7 +80,7 @@ test('IOContext streaming webm with onread', (t) => {
   })
 
   let offset = 0
-  const io = new ffmpeg.IOContext(4096, {
+  using io = new ffmpeg.IOContext(4096, {
     onread: (buffer) => {
       if (!offset) {
         t.ok(Buffer.isBuffer(buffer), 'is buffer')
@@ -112,7 +112,7 @@ test('IOContext streaming mp4 with onseek', (t) => {
   })
 
   let offset = 0
-  const io = new ffmpeg.IOContext(4096, {
+  using io = new ffmpeg.IOContext(4096, {
     onread: (buffer) => {
       if (!offset) {
         t.ok(Buffer.isBuffer(buffer), 'is buffer')

--- a/test/io-context.js
+++ b/test/io-context.js
@@ -157,18 +157,13 @@ test('IOContext.transfer() should transfer ownership between IOContext instances
   const buffer = require('./fixtures/image/sample.jpeg', {
     with: { type: 'binary' }
   })
-
   using sourceIO = new ffmpeg.IOContext(buffer)
-  using targetIO = new ffmpeg.IOContext(null, null) // Empty IOContext
+  using targetIO = new ffmpeg.IOContext(null, null)
 
-  // Transfer ownership
   sourceIO.transfer(targetIO)
 
-  // Verify targetIO works after transfer
   using format = new ffmpeg.InputFormatContext(targetIO)
   t.ok(format, 'targetIO works after transfer')
-
-  // Both should be safe to destroy (via using)
   t.pass('both IOContext instances can be destroyed safely')
 })
 

--- a/test/io-context.js
+++ b/test/io-context.js
@@ -153,6 +153,25 @@ test('IOContext streaming mp4 with onseek', (t) => {
   t.is(audio.length, 34914, `audio size: got ${audio.length}, expected 34914`)
 })
 
+test('IOContext.transfer() should transfer ownership between IOContext instances', (t) => {
+  const buffer = require('./fixtures/image/sample.jpeg', {
+    with: { type: 'binary' }
+  })
+
+  using sourceIO = new ffmpeg.IOContext(buffer)
+  using targetIO = new ffmpeg.IOContext(null, null) // Empty IOContext
+
+  // Transfer ownership
+  sourceIO.transfer(targetIO)
+
+  // Verify targetIO works after transfer
+  using format = new ffmpeg.InputFormatContext(targetIO)
+  t.ok(format, 'targetIO works after transfer')
+
+  // Both should be safe to destroy (via using)
+  t.pass('both IOContext instances can be destroyed safely')
+})
+
 // Helpers
 
 function runStreams(io) {

--- a/test/packet.js
+++ b/test/packet.js
@@ -230,8 +230,8 @@ function fillPacket(packet) {
   const image = require('./fixtures/image/sample.jpeg', {
     with: { type: 'binary' }
   })
-  const io = new ffmpeg.IOContext(image)
-  const format = new ffmpeg.InputFormatContext(io)
+  using io = new ffmpeg.IOContext(image)
+  using format = new ffmpeg.InputFormatContext(io)
   format.readFrame(packet)
 }
 

--- a/test/resampler.js
+++ b/test/resampler.js
@@ -107,8 +107,8 @@ test('resampler with audio from aiff file', (t) => {
   const audio = require('./fixtures/audio/sample.aiff', {
     with: { type: 'binary' }
   })
-  const io = new ffmpeg.IOContext(audio)
-  const format = new ffmpeg.InputFormatContext(io)
+  using io = new ffmpeg.IOContext(audio)
+  using format = new ffmpeg.InputFormatContext(io)
 
   for (const stream of format.streams) {
     const decoder = stream.decoder()
@@ -146,8 +146,6 @@ test('resampler with audio from aiff file', (t) => {
     decoder.destroy()
     resampler.destroy()
   }
-
-  format.destroy()
 })
 
 test('resampler converts between different sample formats', (t) => {
@@ -155,7 +153,7 @@ test('resampler converts between different sample formats', (t) => {
     with: { type: 'binary' }
   })
 
-  const io = new ffmpeg.IOContext(audio)
+  using io = new ffmpeg.IOContext(audio)
   using format = new ffmpeg.InputFormatContext(io)
   const stream = format.streams[0]
   using decoder = stream.decoder()

--- a/test/scaler.js
+++ b/test/scaler.js
@@ -6,7 +6,7 @@ test('it should preseve line number in case of downscale', (t) => {
     with: { type: 'binary' }
   })
 
-  const io = new ffmpeg.IOContext(image)
+  using io = new ffmpeg.IOContext(image)
   using format = new ffmpeg.InputFormatContext(io)
 
   for (const stream of format.streams) {
@@ -14,30 +14,28 @@ test('it should preseve line number in case of downscale', (t) => {
     format.readFrame(packet)
 
     using raw = new ffmpeg.Frame()
-    using rgba = new ffmpeg.Frame()
 
     using decoder = stream.decoder()
+    decoder.open()
     decoder.sendPacket(packet)
     decoder.receiveFrame(raw)
 
-    const targetWidth = decoder.width / 2
-    const targetHeight = decoder.height / 2
-
-    rgba.width = targetWidth
-    rgba.height = targetHeight
-    rgba.pixelFormat = ffmpeg.constants.pixelFormats.RGBA
+    using rgba = new ffmpeg.Frame()
+    rgba.width = decoder.width / 2
+    rgba.height = decoder.height / 2
+    rgba.format = ffmpeg.constants.pixelFormats.RGBA
     rgba.alloc()
 
     using scaler = new ffmpeg.Scaler(
       decoder.pixelFormat,
       decoder.width,
       decoder.height,
-      rgba.pixelFormat,
+      rgba.format,
       rgba.width,
       rgba.height
     )
     const lines = scaler.scale(raw, rgba)
 
-    t.ok(lines == targetHeight)
+    t.ok(lines == rgba.height)
   }
 })


### PR DESCRIPTION
## Context

I saw users shooting themselves into their feet because of this used case:


```js
  using io = new ffmpeg.IOContext(image)
  using inputFormatContext = new ffmpeg.InputFormatContext(io)
```

... which provokes a double free in the current implementation.

## Proposal

Add a `.transfer` method to transfer ownership
