### PR TITLE
Expose format context duration

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -613,6 +613,17 @@ bare_ffmpeg_format_context_get_streams(
   return result;
 }
 
+static int64_t
+bare_ffmpeg_format_context_get_duration(
+  js_env_t *env,
+  js_receiver_t,
+  js_arraybuffer_span_of_t<bare_ffmpeg_format_context_t, 1> context
+) {
+  if (context->handle->duration == AV_NOPTS_VALUE) return -1;
+
+  return context->handle->duration;
+}
+
 static int
 bare_ffmpeg_format_context_get_best_stream_index(
   js_env_t *env,
@@ -4759,6 +4770,7 @@ bare_ffmpeg_exports(js_env_t *env, js_value_t *exports) {
   V("closeOutputFormatContext", bare_ffmpeg_format_context_close_output)
 
   V("getFormatContextStreams", bare_ffmpeg_format_context_get_streams)
+  V("getFormatContextDuration", bare_ffmpeg_format_context_get_duration)
   V("getFormatContextBestStreamIndex", bare_ffmpeg_format_context_get_best_stream_index)
   V("createFormatContextStream", bare_ffmpeg_format_context_create_stream)
   V("readFormatContextFrame", bare_ffmpeg_format_context_read_frame)

--- a/docs/format-context.md
+++ b/docs/format-context.md
@@ -18,6 +18,12 @@ Gets the array of media streams.
 
 **Returns**: Array of `Stream` instances
 
+### `FormatContext.duration`
+
+Gets the container duration in `AV_TIME_BASE` units, or `-1` if unknown.
+
+**Returns**: `number`
+
 ## Methods
 
 ### `FormatContext.readFrame(packet)`

--- a/lib/format-context.js
+++ b/lib/format-context.js
@@ -27,6 +27,10 @@ class FFmpegFormatContext {
     return this._streams
   }
 
+  get duration() {
+    return binding.getFormatContextDuration(this._handle)
+  }
+
   readFrame(packet) {
     return binding.readFormatContextFrame(this._handle, packet._handle)
   }

--- a/test/format-context.js
+++ b/test/format-context.js
@@ -72,6 +72,17 @@ test('InputFormatContext.inputFormat should expose a inputFormat getter', (t) =>
   t.ok(inputFormat instanceof ffmpeg.InputFormat)
 })
 
+test('InputFormatContext.duration should expose the container duration', (t) => {
+  const video = require('./fixtures/video/sample.mp4', {
+    with: { type: 'binary' }
+  })
+
+  using io = new ffmpeg.IOContext(video)
+  using inputFormatContext = new ffmpeg.InputFormatContext(io)
+
+  t.is(inputFormatContext.duration, 4000000)
+})
+
 // OutputFormatContext
 
 test('OutputFormatContext should expose an outputFormat getter', (t) => {


### PR DESCRIPTION
Adds support to read the duration of a media file from its container:

```js
using io = new ffmpeg.IOContext(video)
using inputFormatContext = new ffmpeg.InputFormatContext(io)

const duration = inputFormatContext.duration
```

Previously duration could only be read from the stream.